### PR TITLE
Added character encoding declaration for UTF-8

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
 
-	<meta charset="utf-8">
+    <meta charset="utf-8">
     <meta name="description" content="SCU&#8226;classes is a website that makes choosing classes and building schedules much easier.  Never use CourseAvail again!">
     <link rel="icon" href="favicon.ico" />
   </head>


### PR DESCRIPTION
I have a chrome plugin that whines when a charset isn't declared, and I knew SCUclasses was OSS, so I figured I could help out a bit. 
