### PR TITLE
Add link to shareable page

### DIFF
--- a/app/views/home/_share_schedule_modal.html.erb
+++ b/app/views/home/_share_schedule_modal.html.erb
@@ -10,7 +10,7 @@
 
         <br/>
 
-        <h4>{{shareLink()}}</h4>
+        <h4><a href="{{shareLink()}}" target="_blank">{{shareLink()}}<a/></h4>
 
         <br/>
 


### PR DESCRIPTION
Link opens in a new window, and makes it easier to bookmark or share without having to cut and paste